### PR TITLE
Implement coder routes and seed utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-/.DS_Storenode_modules/
+/.DS_Store
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ A Cloudflare Workers-based system for intelligent task management and orchestrat
 - `GET /api/docs/:section` - Retrieve documentation by section
 - `POST /api/docs/assign-agent` - Queue AI bot assignment for documentation
 
+### Coder API
+- `POST /api/coder/start-task` - Mark a task as started by a coder
+- `POST /api/coder/complete-task` - Mark a task as completed
+- `POST /api/coder/report-error` - Report an error during task execution
+- `GET /api/next-task?coderType=codex&projectId=optional` - Fetch the next available task
+
+### Seeding
+- `POST /api/seed-tasks` - Seed tasks from CSV or JSON payload
+
 ## 🤖 Agent System
 
 ### Available Agents

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "deploy": "cd ../worker && pnpm install && pnpm run build && cd ../frontend && pnpm install && pnpm run build && cd ../backend && pnpm install && pnpm run migrate:local && pnpm run migrate:remote && wrangler deploy",
     "dev": "wrangler dev",
     "start": "wrangler dev",
+    "build": "tsc",
     "migrate:local": "wrangler d1 migrations apply DB --local",
     "migrate:remote": "wrangler d1 migrations apply DB --remote"
   },
@@ -20,6 +21,7 @@
     "@types/node": "^22.5.4",
     "axios": "^1.10.0",
     "body-parser": "^1.20.3",
+    "csv-parse": "^5.6.0",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "express-session": "^1.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       body-parser:
         specifier: ^1.20.3
         version: 1.20.3
+      csv-parse:
+        specifier: ^5.6.0
+        version: 5.6.0
       dotenv:
         specifier: ^16.4.5
         version: 16.5.0
@@ -251,6 +254,9 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  csv-parse@5.6.0:
+    resolution: {integrity: sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -893,6 +899,8 @@ snapshots:
   cookie@0.7.2: {}
 
   create-require@1.1.1: {}
+
+  csv-parse@5.6.0: {}
 
   debug@2.6.9:
     dependencies:

--- a/seeds/tasks.csv
+++ b/seeds/tasks.csv
@@ -1,0 +1,6 @@
+Task Name,Description,Status,Priority
+Create `coders` D1 table,"Design and deploy the `coders` table with fields for id, type, name, assigned_project_id, and config.",to do,High
+Add coder selection to project initializer,"Update the project creation flow to support selecting a coder type (codex, cursor, cline, human).",to do,High
+"Generate `.clinerules`, `cursor.config.json`, or Codex bindings",Create config templates and examples for each coder type. Output appropriate file during project initialization.,to do,High
+Create helper file for `postTaskUpdate()`,Export reusable helper function for updating task status. Include example usage for coders.,to do,High
+Build coder routing endpoints,"Create `/api/coder/start-task`, `/complete-task`, and `/report-error` endpoints for task state transitions.",to do,High

--- a/seeds/tasks.json
+++ b/seeds/tasks.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "task-1",
+    "name": "Create coders D1 table",
+    "description": "Design and deploy the coders table with fields for id, type, name, assigned_project_id, and config.",
+    "status": "to do",
+    "priority": "High"
+  },
+  {
+    "id": "task-2",
+    "name": "Add coder selection to project initializer",
+    "description": "Update the project creation flow to support selecting a coder type (codex, cursor, cline, human).",
+    "status": "to do",
+    "priority": "High"
+  },
+  {
+    "id": "task-3",
+    "name": "Generate configuration templates",
+    "description": "Create config templates and examples for each coder type. Output appropriate file during project initialization.",
+    "status": "to do",
+    "priority": "High"
+  },
+  {
+    "id": "task-4",
+    "name": "Create helper for postTaskUpdate",
+    "description": "Export reusable helper function for updating task status. Include example usage for coders.",
+    "status": "to do",
+    "priority": "High"
+  },
+  {
+    "id": "task-5",
+    "name": "Build coder routing endpoints",
+    "description": "Create /api/coder/start-task, /complete-task, and /report-error endpoints for task state transitions.",
+    "status": "to do",
+    "priority": "High"
+  }
+]

--- a/src/ai/aiWriter.ts
+++ b/src/ai/aiWriter.ts
@@ -5,8 +5,8 @@
  * These files serve as task assignments for AI agents to collaborate on.
  */
 
-import { logger } from './logger';
-import { generateUUID } from './uuid';
+import { logger } from '../utils/logger';
+import { generateUUID } from '../utils/uuid';
 
 export interface AgentTask {
   title: string;
@@ -21,34 +21,51 @@ export interface AgentTask {
 }
 
 export async function writeAgentFile({
-    title,
-    file,
-    goal,
-    details = [],
-    env
-  }: {
-    title: string;
-    file: string;
-    goal: string;
-    details?: string[];
-    env: any;
-  }): Promise<void> {
+  title,
+  file,
+  goal,
+  details = [],
+  env
+}: {
+  title: string;
+  file: string;
+  goal: string;
+  details?: string[];
+  env: any;
+}): Promise<{
+  success: boolean;
+  fileKey: string;
+  presignedUrl?: string;
+  metadata: Record<string, any>;
+  error?: string;
+}> {
+  try {
     const content = `# Task: ${title}
-  
-  **File:** ${file}  
-  **Goal:** ${goal}  
-  
-  **Details:**
-  ${details.map((d) => `- ${d}`).join("\n")}
-  `;
-  
+
+**File:** ${file}
+**Goal:** ${goal}
+
+**Details:**
+${details.map((d) => `- ${d}`).join('\n')}
+`;
+
     const uuid = crypto.randomUUID();
     const filename = `cursor-task-${uuid}.agent.md`;
     const kvKey = `cursor-tasks/${filename}`;
-  
+
     await env.R2.put(kvKey, content, {
-      httpMetadata: { contentType: "text/markdown" }
+      httpMetadata: { contentType: 'text/markdown' }
     });
-  
-    console.log(`🧠 Cursor task written to R2 as ${kvKey}`);
+
+    logger.info('Agent file written', { key: kvKey });
+    return { success: true, fileKey: kvKey, metadata: { title, goal, details } };
+  } catch (err) {
+    logger.error('writeAgentFile failed', err instanceof Error ? err : new Error(String(err)));
+    return {
+      success: false,
+      fileKey: '',
+      error: err instanceof Error ? err.message : String(err),
+      metadata: { title, goal, details }
+    };
   }
+}

--- a/src/orchestrate/handlers/assignAgentTask.ts
+++ b/src/orchestrate/handlers/assignAgentTask.ts
@@ -5,8 +5,8 @@
  * AI agent task files in R2 storage.
  */
 
-import { writeAgentFile, AgentTask } from '../ai/aiWriter';
-import { logger } from '../utils/logger';
+import { writeAgentFile, AgentTask } from '../../ai/aiWriter';
+import { logger } from '../../utils/logger';
 
 export interface AssignAgentTaskRequest {
   title: string;
@@ -68,7 +68,13 @@ export async function handleAssignAgentTask(
     });
 
     // Create agent task
-    const result = await writeAgentFile(body, env);
+    const result = await writeAgentFile({
+      title: body.title,
+      file: body.relatedFile || 'task.md',
+      goal: body.description,
+      details: body.tags || [],
+      env
+    });
 
     if (!result.success) {
       return new Response(
@@ -101,7 +107,7 @@ export async function handleAssignAgentTask(
       data: {
         fileKey: result.fileKey,
         presignedUrl: result.presignedUrl,
-        metadata: result.metadata
+        metadata: result.metadata as any
       }
     };
 

--- a/src/routes/coder.ts
+++ b/src/routes/coder.ts
@@ -1,0 +1,73 @@
+import { logger } from '../utils/logger';
+
+interface CoderRequest {
+  coderId: string;
+  taskId: string;
+  error?: string;
+}
+
+export async function startTask(req: Request, env: any): Promise<Response> {
+  const body: CoderRequest = await req.json();
+  try {
+    await env.DB.prepare(
+      'UPDATE tasks SET status = ? WHERE id = ?'
+    ).bind('in_progress', body.taskId).run();
+    logger.info('Coder started task', { coderId: body.coderId, taskId: body.taskId });
+    return Response.json({ success: true });
+  } catch (err) {
+    logger.error('startTask error', err instanceof Error ? err : new Error(String(err)));
+    return Response.json({ success: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}
+
+export async function completeTask(req: Request, env: any): Promise<Response> {
+  const body: CoderRequest = await req.json();
+  try {
+    await env.DB.prepare(
+      'UPDATE tasks SET status = ? WHERE id = ?'
+    ).bind('completed', body.taskId).run();
+    logger.info('Coder completed task', { coderId: body.coderId, taskId: body.taskId });
+    return Response.json({ success: true });
+  } catch (err) {
+    logger.error('completeTask error', err instanceof Error ? err : new Error(String(err)));
+    return Response.json({ success: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}
+
+export async function reportError(req: Request, env: any): Promise<Response> {
+  const body: CoderRequest = await req.json();
+  try {
+    await env.DB.prepare(
+      'UPDATE tasks SET status = ?, description = description || ? WHERE id = ?'
+    ).bind('error', body.error || '', body.taskId).run();
+    logger.info('Coder reported error', { coderId: body.coderId, taskId: body.taskId });
+    return Response.json({ success: true });
+  } catch (err) {
+    logger.error('reportError error', err instanceof Error ? err : new Error(String(err)));
+    return Response.json({ success: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}
+
+export async function nextTask(req: Request, env: any): Promise<Response> {
+  const url = new URL(req.url);
+  const coderType = url.searchParams.get('coderType') || 'codex';
+  const projectId = url.searchParams.get('projectId');
+  try {
+    let query = 'SELECT * FROM tasks WHERE status = ?';
+    const params: any[] = ['to do'];
+    if (projectId) {
+      query += ' AND project_id = ?';
+      params.push(projectId);
+    }
+    query += ' ORDER BY priority DESC LIMIT 1';
+    const result = await env.DB.prepare(query).bind(...params).first();
+    if (!result) {
+      return Response.json({ task: null });
+    }
+    logger.info('Next task fetched', { coderType, projectId, taskId: result.id });
+    return Response.json({ task: result });
+  } catch (err) {
+    logger.error('nextTask error', err instanceof Error ? err : new Error(String(err)));
+    return Response.json({ success: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/src/utils/seeder.ts
+++ b/src/utils/seeder.ts
@@ -1,0 +1,46 @@
+import { parse } from 'csv-parse/sync';
+import { logger } from './logger';
+
+export async function ensureTables(env: any): Promise<void> {
+  await env.DB.prepare(
+    'CREATE TABLE IF NOT EXISTS coders (id TEXT PRIMARY KEY, type TEXT, name TEXT, assigned_project_id TEXT, config TEXT)'
+  ).run();
+  await env.DB.prepare(
+    'CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, name TEXT, description TEXT, status TEXT, priority TEXT, project_id TEXT)'
+  ).run();
+}
+
+interface SeedTask {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+  priority: string;
+}
+
+export async function seedFromCSV(csvText: string, env: any): Promise<void> {
+  const records = parse(csvText, { columns: true, skip_empty_lines: true });
+  for (const rec of records) {
+    const task: SeedTask = {
+      id: crypto.randomUUID(),
+      name: rec['Task Name'] || rec.name,
+      description: rec['Description'] || '',
+      status: rec['Status'] || 'to do',
+      priority: rec['Priority'] || 'Medium'
+    };
+    await env.DB.prepare(
+      'INSERT INTO tasks (id, name, description, status, priority) VALUES (?, ?, ?, ?, ?)'
+    ).bind(task.id, task.name, task.description, task.status, task.priority).run();
+  }
+  logger.info('Seeded tasks from CSV', { count: records.length });
+}
+
+export async function seedFromJSON(jsonText: string, env: any): Promise<void> {
+  const tasks: SeedTask[] = JSON.parse(jsonText);
+  for (const task of tasks) {
+    await env.DB.prepare(
+      'INSERT INTO tasks (id, name, description, status, priority) VALUES (?, ?, ?, ?, ?)'
+    ).bind(task.id, task.name, task.description, task.status, task.priority).run();
+  }
+  logger.info('Seeded tasks from JSON', { count: tasks.length });
+}


### PR DESCRIPTION
## Summary
- add TypeScript build script
- implement coder routing endpoints
- add seed utilities and example task data
- fix imports and typings for ai writer
- update `.gitignore`
- fix newline at EOF
- document coder APIs and seeding in README

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859f1e275d4832eae52a79a1a964eb5